### PR TITLE
Updated pom file to simplify dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.8.RELEASE</version>
+		<version>2.2.4.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -33,11 +33,32 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<junit.jupiter.version>5.5.2</junit.jupiter.version>
-		<spring.version>5.1.6.RELEASE</spring.version>
 		<springdoc.openapi.version>1.1.49</springdoc.openapi.version>
 		<maven.surefire.version>2.22.2</maven.surefire.version>
 		<micrometer.version>1.3.2</micrometer.version>
+		<spring.version>5.2.6.RELEASE</spring.version>
+		<rest.assured.version>4.0.0</rest.assured.version>
+		<hibernate.ehcache.version>5.4.2.Final</hibernate.ehcache.version>
+		<h2.version>1.4.199</h2.version>
+		<javax.inject.version>1</javax.inject.version>
+		<mysql.connector.java.version>8.0.17</mysql.connector.java.version>
+		<jasypt.spring.boot.starter.version>2.1.2</jasypt.spring.boot.starter.version>
+		<flywaydb.version>5.2.4</flywaydb.version>
+		<hibernate.validator.version>6.0.17.Final</hibernate.validator.version>
+		<mockserver.version>5.7.0</mockserver.version>
+		<testcontainers.junit.version>1.12.5</testcontainers.junit.version>
+		<gson.version>2.8.5</gson.version>
+		<okhttp3.version>4.2.2</okhttp3.version>
+		<jaxws.ri.version>2.3.0</jaxws.ri.version>
+		<mojo.jaxb2.version>2.4</mojo.jaxb2.version>
+		<jaxb2.annotate.test.version>1.0.0</jaxb2.annotate.test.version>
+		<jaxb2.basics.annotate.version>1.0.2</jaxb2.basics.annotate.version>
+		<jaxb.xjc.version>2.3.2</jaxb.xjc.version>
+		<jakarta.activation.version>1.2.1</jakarta.activation.version>
+		<jaxb2.fluent.version>3.0</jaxb2.fluent.version>
+		<maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
+		<build.helper.maven.version>3.0.0</build.helper.maven.version>
+		<exec.maven.plugin.version>1.6.0</exec.maven.plugin.version>
 	</properties>
 
 	<dependencies>
@@ -70,10 +91,6 @@
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
 			<version>${micrometer.version}</version>
@@ -81,7 +98,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.17.Final</version>
+			<version>${hibernate.validator.version}</version>
 		</dependency>
 
 		<dependency>
@@ -93,13 +110,13 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.4.199</version>
+			<version>${h2.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-ehcache</artifactId>
-			<version>5.4.2.Final</version>
+			<version>${hibernate.ehcache.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -110,12 +127,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -136,52 +147,34 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.activemq</groupId>
-			<artifactId>activemq-core</artifactId>
-			<version>5.7.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10.4</version>
-		</dependency>
-
-		<dependency>
 			<groupId>javax.inject</groupId>
 			<artifactId>javax.inject</artifactId>
-			<version>1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.jasypt</groupId>
-			<artifactId>jasypt</artifactId>
-			<version>1.9.3</version>
+			<version>${javax.inject.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.github.ulisesbocchio</groupId>
 			<artifactId>jasypt-spring-boot-starter</artifactId>
-			<version>2.1.2</version>
+			<version>${jasypt.spring.boot.starter.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.17</version>
+			<version>${mysql.connector.java.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
-			<version>5.2.4</version>
+			<version>${flywaydb.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.sun.xml.ws</groupId>
 			<artifactId>jaxws-ri</artifactId>
-			<version>2.3.0</version>
+			<version>${jaxws.ri.version}</version>
 			<type>pom</type>
 			<exclusions>
 				<exclusion>
@@ -201,65 +194,57 @@
 
 		<!-- Test dependicies -->
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/org.mock-server/mockserver-client -->
-		<dependency>
 			<groupId>org.mock-server</groupId>
 			<artifactId>mockserver-client-java</artifactId>
-			<version>5.7.0</version>
+			<version>${mockserver.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>1.12.5</version>
+			<version>${testcontainers.junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured</artifactId>
-			<version>4.0.0</version>
+			<version>${rest.assured.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>json-path</artifactId>
-			<version>4.0.0</version>
+			<version>${rest.assured.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>xml-path</artifactId>
-			<version>4.0.0</version>
+			<version>${rest.assured.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
+			<version>${gson.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>4.2.2</version>
+			<version>${okhttp3.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>4.2.2</version>
+			<version>${okhttp3.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -278,7 +263,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxb2-maven-plugin</artifactId>
-				<version>2.4</version>
+				<version>${mojo.jaxb2.version}</version>
 				<executions>
 					<execution>
 						<id>xjc</id>
@@ -310,33 +295,34 @@
 					<dependency>
 						<groupId>org.jvnet.jaxb2_commons</groupId>
 						<artifactId>jaxb2-annotate-plugin-test-annox-annotations</artifactId>
-						<version>1.0.0</version>
+						<version>${jaxb2.annotate.test.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.jvnet.jaxb2_commons</groupId>
 						<artifactId>jaxb2-basics-annotate</artifactId>
-						<version>1.0.2</version>
+						<version>${jaxb2.basics.annotate.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.glassfish.jaxb</groupId>
 						<artifactId>jaxb-xjc</artifactId>
-						<version>2.3.2</version>
+						<version>${jaxb.xjc.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>com.sun.activation</groupId>
 						<artifactId>jakarta.activation</artifactId>
-						<version>1.2.1</version>
+						<version>${jakarta.activation.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.jvnet.jaxb2_commons</groupId>
 						<artifactId>jaxb2-fluent-api</artifactId>
-						<version>3.0</version>
+						<version>${jaxb2.fluent.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
+				<version>${maven.antrun.plugin.version}</version>
 				<executions>
 					<execution>
 						<id>createWsImportDir</id>
@@ -355,6 +341,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${build.helper.maven.version}</version>
 				<executions>
 					<execution>
 						<id>add-source</id>
@@ -373,6 +360,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
+				<version>${exec.maven.plugin.version}</version>
 				<executions>
 					<execution>
 						<id>firstFile</id>
@@ -399,7 +387,6 @@
 				</executions>
 			</plugin>
 		</plugins>
-		<outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
 	</build>
 
 	<profiles>

--- a/src/main/java/se/jsquad/configuration/ApplicationConfiguration.java
+++ b/src/main/java/se/jsquad/configuration/ApplicationConfiguration.java
@@ -17,7 +17,6 @@
 package se.jsquad.configuration;
 
 
-import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -95,7 +94,6 @@ import java.util.Properties;
 @ComponentScan(basePackages = {"se.jsquad"})
 @EnableJpaRepositories(basePackages = {"se.jsquad.repository"})
 @EnableAspectJAutoProxy
-@EnableEncryptableProperties
 @EnableConfigurationProperties(value = {OpenBankDatabaseConfiguration.class, SecurityDatabaseConfiguration.class,
         SecurityJpaConfiguration.class, OpenBankJpaConfiguration.class, WorldWebClientConfiguration.class})
 public class ApplicationConfiguration {


### PR DESCRIPTION
Added property version attributes for jar dependencies to simplify
minor/major and parent maven jar version upgrade with automation
script logic.

Updated Spring Boot 2 version from 2.18 to 2.2.4 and removed
unnessesary maven jar dependencies that is included in Spring Boot
2.2.4.