### PR TITLE
Added editorconfig and gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = false
+max_line_length = 120
+tab_width = 4
+
+[*.java]
+indent_style = space
+
+[{*.jhm,*.xul,*.rng,*.qrc,*.wsdl,*.fxml,*.bpmn,*.pom,*.xslt,*.jrxml,*.ant,*.xsl,*.xsd,*.tld,*.jnlp,*.wadl,*.xml}]
+indent_style = space
+
+[{*.pyw,*.py}]
+indent_style = space
+
+[{*.yml,*.yaml}]
+indent_size = 2
+
+[{bowerrc,.babelrc,jest.config,.stylelintrc,.eslintrc,*.jsb3,*.jsb2,*.json}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,46 @@
+###############################
+# Git Line Endings            #
+###############################
+
+# Set default behaviour to automatically normalize line endings.
+* text=auto
+
+# Force bash scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.sh text eol=lf
+.travis.yml text eol=lf
+*.java text eol=lf
+*.xml text eol=lf
+*.xsd text eol=lf
+*.yaml text eol=lf
+.gitignore text eol=lf
+*.md text eol=lf
+
+###############################
+# Git Large File System (LFS) #
+###############################
+
+# Archives
+*.7z filter=lfs diff=lfs merge=lfs -text
+*.br filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.tar filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+
+# Documents
+*.pdf filter=lfs diff=lfs merge=lfs -text
+
+# Images
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.pdf filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+
+# Fonts
+*.woff2 filter=lfs diff=lfs merge=lfs -text
+
+# Other
+*.exe filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Added editorconfig and gitattributes to set default indentation,
end of line type per file type, charset etc to prevent users
comitting files not following repository file practise.