### PR TITLE
Improved container integration URI test setup

### DIFF
--- a/service/src/test/java/se/jsquad/integration/DeepAndShallowHealthCheckOkIT.java
+++ b/service/src/test/java/se/jsquad/integration/DeepAndShallowHealthCheckOkIT.java
@@ -19,31 +19,29 @@ package se.jsquad.integration;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import se.jsquad.health.check.DeepSystemStatusResponse;
 import se.jsquad.health.check.HealthStatus;
 import se.jsquad.health.check.ShallowSystemStatusResponse;
 
-import java.net.URI;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static se.jsquad.integration.RyukIntegration.BASE_PATH_ACTUATOR;
+import static se.jsquad.integration.RyukIntegration.OPENBANK_MONITORING;
+import static se.jsquad.integration.RyukIntegration.PROTOCOL_HTTP;
 
 public class DeepAndShallowHealthCheckOkIT extends AbstractTestContainerSetup {
-    @BeforeEach
-    void setupEndpointForRestAssured() {
-        setupEndpointForRestAssuredAdapterHttp();
-    }
-    
     @Test
-    void testShallowHealthCheck() {
+    void testShallowHealthCheck() throws MalformedURLException, URISyntaxException {
         // When
         Response response = RestAssured
                 .given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/shallowhealth")).andReturn();
+                .get(toURI(BASE_PATH_ACTUATOR + "/shallowhealth", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
 
         // Then
         ShallowSystemStatusResponse shallowSystemStatusResponse = gson.fromJson(response.getBody().asString(),
@@ -54,14 +52,14 @@ public class DeepAndShallowHealthCheckOkIT extends AbstractTestContainerSetup {
     }
 
     @Test
-    void testDeepHealthCheck() {
+    void testDeepHealthCheck() throws MalformedURLException, URISyntaxException {
         // When
         Response response = RestAssured
                 .given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/deephealth")).andReturn();
+                .get(toURI(BASE_PATH_ACTUATOR + "/deephealth", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
 
         // Then
         DeepSystemStatusResponse deepSystemStatusResponse = gson.fromJson(response.getBody().asString(),

--- a/service/src/test/java/se/jsquad/integration/DeepHealthCheckNotOkIT.java
+++ b/service/src/test/java/se/jsquad/integration/DeepHealthCheckNotOkIT.java
@@ -21,26 +21,24 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import se.jsquad.health.check.DeepSystemStatusResponse;
 import se.jsquad.health.check.HealthStatus;
 
 import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static se.jsquad.integration.RyukIntegration.BASE_PATH_ACTUATOR;
+import static se.jsquad.integration.RyukIntegration.OPENBANK_MONITORING;
+import static se.jsquad.integration.RyukIntegration.PROTOCOL_HTTP;
 
 public class DeepHealthCheckNotOkIT extends AbstractTestContainerSetup {
-    @BeforeEach
-    void setupEndpointForRestAssured() {
-        setupEndpointForRestAssuredAdapterHttp();
-    }
-    
     @Test
     void testDeepHealthCheckNotOk() throws NoSuchMethodException, InvocationTargetException,
-        IllegalAccessException, ApiException {
+        IllegalAccessException, ApiException, MalformedURLException, URISyntaxException {
         // Given
         executeContainerPodCLI("openbankdb", "KILL");
         executeContainerPodCLI("securitydb", "KILL");
@@ -51,7 +49,7 @@ public class DeepHealthCheckNotOkIT extends AbstractTestContainerSetup {
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/deephealth")).andReturn();
+                .get(toURI(BASE_PATH_ACTUATOR + "/deephealth", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
             
             DeepSystemStatusResponse deepSystemStatusResponse = gson.fromJson(response.getBody().asString(),
                 DeepSystemStatusResponse.class);
@@ -67,7 +65,7 @@ public class DeepHealthCheckNotOkIT extends AbstractTestContainerSetup {
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/deephealth")).andReturn();
+                .get(toURI(BASE_PATH_ACTUATOR + "/deephealth", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
 
         // Then
         DeepSystemStatusResponse deepSystemStatusResponse = gson.fromJson(response.getBody().asString(),
@@ -86,13 +84,12 @@ public class DeepHealthCheckNotOkIT extends AbstractTestContainerSetup {
     
         Awaitility.await().pollDelay(Duration.ofSeconds(5)).atMost(Duration.ofMinutes(10)).until(() -> {
             try {
-                setupEndpointForRestAssuredAdapterHttp();
                 Response response1 = RestAssured
                     .given()
                     .contentType(ContentType.JSON)
                     .accept(ContentType.JSON)
                     .when()
-                    .get(URI.create("/deephealth")).andReturn();
+                    .get(toURI(BASE_PATH_ACTUATOR + "/deephealth", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
     
                 DeepSystemStatusResponse deepSystemStatusResponse1 = gson.fromJson(response1.getBody().asString(),
                     DeepSystemStatusResponse.class);

--- a/service/src/test/java/se/jsquad/integration/GetClientInformationRestControllerIT.java
+++ b/service/src/test/java/se/jsquad/integration/GetClientInformationRestControllerIT.java
@@ -19,7 +19,6 @@ package se.jsquad.integration;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import se.jsquad.client.info.ClientApi;
@@ -30,18 +29,17 @@ import se.jsquad.client.info.ClientRequest;
 import se.jsquad.client.info.PersonApi;
 import se.jsquad.client.info.TypeApi;
 
-import java.net.URI;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static se.jsquad.integration.RyukIntegration.BASE_PATH_API;
+import static se.jsquad.integration.RyukIntegration.OPENBANK_SERVICE;
+import static se.jsquad.integration.RyukIntegration.PROTOCOL_HTTPS;
 
 public class GetClientInformationRestControllerIT extends AbstractTestContainerSetup {
-    @BeforeEach
-    void setupEndpointForRestAssured() {
-        setupEndpointForRestAssuredAdapterHttps();
-    }
-    
     @Test
-    void updateClientInformation() {
+    void updateClientInformation() throws MalformedURLException, URISyntaxException {
         // Given
         ClientInformationRequest clientInformationRequest = new ClientInformationRequest();
 
@@ -57,7 +55,8 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
                 .accept(ContentType.JSON)
                 .body(clientInformationRequest)
                 .when()
-                .put(URI.create("/update/client/information/")).andReturn();
+                .put(toURI(BASE_PATH_API + "/update/client/information/", PROTOCOL_HTTPS, OPENBANK_SERVICE))
+            .andReturn();
 
         ClientInformationResponse clientApiResponse = gson.fromJson(response.getBody().asString(),
                 ClientInformationResponse.class);
@@ -68,7 +67,7 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
     }
 
     @Test
-    void updateClientInformationWithBadContent() {
+    void updateClientInformationWithBadContent() throws MalformedURLException, URISyntaxException {
         // Given
         ClientInformationRequest clientInformationRequest = new ClientInformationRequest();
 
@@ -84,7 +83,8 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
                 .accept(ContentType.JSON)
                 .body(clientInformationRequest)
                 .when()
-                .put(URI.create("/update/client/information/")).andReturn();
+                .put(toURI(BASE_PATH_API + "/update/client/information/", PROTOCOL_HTTPS, OPENBANK_SERVICE))
+            .andReturn();
 
         // Then
         assertEquals(400, response.getStatusCode());
@@ -92,7 +92,7 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
     }
 
     @Test
-    void testGetClientInformation() {
+    void testGetClientInformation() throws MalformedURLException, URISyntaxException {
         // Given
         String personIdentificationNumber = "191212121212";
 
@@ -102,7 +102,8 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/client/info/" + personIdentificationNumber)).andReturn();
+                .get(toURI(BASE_PATH_API + "/client/info/" + personIdentificationNumber, PROTOCOL_HTTPS,
+                    OPENBANK_SERVICE)).andReturn();
 
         ClientApi clientApi = gson.fromJson(response.getBody().print(), ClientApi.class);
 
@@ -129,7 +130,7 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
     }
 
     @Test
-    void testGetClientInformationWithInvalidPersonIdenticationNumber() {
+    void testGetClientInformationWithInvalidPersonIdenticationNumber() throws MalformedURLException, URISyntaxException {
         // Given
         String personIdentificationNumber = "123";
 
@@ -139,7 +140,8 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/client/info/" + personIdentificationNumber)).andReturn();
+                .get(toURI(BASE_PATH_API + "/client/info/" + personIdentificationNumber, PROTOCOL_HTTPS,
+                    OPENBANK_SERVICE)).andReturn();
 
 
         // Then
@@ -149,7 +151,7 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
     }
 
     @Test
-    void testGetClientInformationByClientRequestBody() {
+    void testGetClientInformationByClientRequestBody() throws MalformedURLException, URISyntaxException {
         // Given
         ClientRequest clientRequest = new ClientRequest();
         clientRequest.setClientData(new ClientData());
@@ -163,7 +165,7 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
                 .accept(ContentType.JSON)
                 .when()
                 .body(gson.toJson(clientRequest))
-                .get(URI.create("/get/client/info/")).andReturn();
+                .get(toURI(BASE_PATH_API + "/get/client/info/", PROTOCOL_HTTPS, OPENBANK_SERVICE)).andReturn();
 
         ClientApi clientApi = gson.fromJson(response.getBody().print(), ClientApi.class);
 
@@ -192,7 +194,7 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
     }
 
     @Test
-    void testGetClientInformationWithRequestBodyConstraints() {
+    void testGetClientInformationWithRequestBodyConstraints() throws MalformedURLException, URISyntaxException {
         // Given
         ClientRequest clientRequest = null;
 
@@ -203,7 +205,7 @@ public class GetClientInformationRestControllerIT extends AbstractTestContainerS
                 .accept(ContentType.JSON)
                 .when()
                 .body(gson.toJson(clientRequest))
-                .get(URI.create("/get/client/info/")).andReturn();
+                .get(toURI(BASE_PATH_API + "/get/client/info/", PROTOCOL_HTTPS, OPENBANK_SERVICE)).andReturn();
 
 
         // Then

--- a/service/src/test/java/se/jsquad/integration/GetHelloWorldErrorRestControllerIT.java
+++ b/service/src/test/java/se/jsquad/integration/GetHelloWorldErrorRestControllerIT.java
@@ -20,32 +20,30 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.model.Delay;
 import org.mockserver.model.Header;
 import org.springframework.http.MediaType;
 
-import java.net.URI;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static se.jsquad.integration.RyukIntegration.BASE_PATH_API;
+import static se.jsquad.integration.RyukIntegration.OPENBANK_SERVICE;
+import static se.jsquad.integration.RyukIntegration.PROTOCOL_HTTPS;
 
 public class GetHelloWorldErrorRestControllerIT extends AbstractTestContainerSetup {
-    @BeforeEach
-    void setupEndpointForRestAssured() {
-        setupEndpointForRestAssuredAdapterHttps();
-    }
-    
     @AfterEach
     void resetMockServerClient() {
         mockServerClient.reset();
     }
     
     @Test
-    void testGetHelloWorldRestResponseServerError() {
+    void testGetHelloWorldRestResponseServerError() throws MalformedURLException, URISyntaxException {
         // Given
         mockServerClient
                 .when(request()
@@ -63,7 +61,7 @@ public class GetHelloWorldErrorRestControllerIT extends AbstractTestContainerSet
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/get/hello/world")).andReturn();
+                .get(toURI(BASE_PATH_API + "/get/hello/world", PROTOCOL_HTTPS, OPENBANK_SERVICE)).andReturn();
 
         // Then
         assertEquals(500, response.getStatusCode());

--- a/service/src/test/java/se/jsquad/integration/GetHelloWorldOkRestControllerIT.java
+++ b/service/src/test/java/se/jsquad/integration/GetHelloWorldOkRestControllerIT.java
@@ -20,32 +20,30 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.model.Delay;
 import org.mockserver.model.Header;
 import se.jsquad.client.info.WorldApiResponse;
 
-import java.net.URI;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static se.jsquad.integration.RyukIntegration.BASE_PATH_API;
+import static se.jsquad.integration.RyukIntegration.OPENBANK_SERVICE;
+import static se.jsquad.integration.RyukIntegration.PROTOCOL_HTTPS;
 
 public class GetHelloWorldOkRestControllerIT extends AbstractTestContainerSetup {
-    @BeforeEach
-    void setupEndpointForRestAssured() {
-        setupEndpointForRestAssuredAdapterHttps();
-    }
-    
     @AfterEach
     void resetMockServerClient() {
         mockServerClient.reset();
     }
     
     @Test
-    void testGetHelloWorldRestResponse() {
+    void testGetHelloWorldRestResponse() throws MalformedURLException, URISyntaxException {
         // Given
         WorldApiResponse worldApiResponse = new WorldApiResponse();
         worldApiResponse.setMessage("Hello world");
@@ -66,7 +64,7 @@ public class GetHelloWorldOkRestControllerIT extends AbstractTestContainerSetup 
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/get/hello/world")).andReturn();
+                .get(toURI(BASE_PATH_API + "/get/hello/world", PROTOCOL_HTTPS, OPENBANK_SERVICE)).andReturn();
         
         // Then
         assertEquals(200, response.getStatusCode());

--- a/service/src/test/java/se/jsquad/integration/MonitorPrometheusDownStatusIT.java
+++ b/service/src/test/java/se/jsquad/integration/MonitorPrometheusDownStatusIT.java
@@ -21,27 +21,25 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import se.jsquad.health.check.DeepSystemStatusResponse;
 import se.jsquad.health.check.HealthStatus;
 
 import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static se.jsquad.integration.RyukIntegration.BASE_PATH_ACTUATOR;
+import static se.jsquad.integration.RyukIntegration.OPENBANK_MONITORING;
+import static se.jsquad.integration.RyukIntegration.PROTOCOL_HTTP;
 
 public class MonitorPrometheusDownStatusIT extends AbstractTestContainerSetup {
-    @BeforeEach
-    void setupEndpointForRestAssured() {
-        setupEndpointForRestAssuredAdapterHttp();
-    }
-    
     @Test
     void testDeepHealthMetricsNotOk() throws NoSuchMethodException, InvocationTargetException,
-        IllegalAccessException, ApiException {
+        IllegalAccessException, ApiException, MalformedURLException, URISyntaxException {
         // Given
         executeContainerPodCLI("openbankdb", "KILL");
         executeContainerPodCLI("securitydb", "KILL");
@@ -52,7 +50,7 @@ public class MonitorPrometheusDownStatusIT extends AbstractTestContainerSetup {
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .when()
-                .get(URI.create("/deephealth")).andReturn();
+                .get(toURI(BASE_PATH_ACTUATOR + "/deephealth", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
         
             DeepSystemStatusResponse deepSystemStatusResponse = gson.fromJson(response.getBody().asString(),
                 DeepSystemStatusResponse.class);
@@ -68,7 +66,7 @@ public class MonitorPrometheusDownStatusIT extends AbstractTestContainerSetup {
                 .contentType(ContentType.ANY)
                 .accept(ContentType.ANY)
                 .when()
-                .get(URI.create("/prometheus")).andReturn();
+                .get(toURI(BASE_PATH_ACTUATOR + "/prometheus", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
 
         // Then
         assertEquals(200, response.getStatusCode());
@@ -85,13 +83,12 @@ public class MonitorPrometheusDownStatusIT extends AbstractTestContainerSetup {
     
         Awaitility.await().pollDelay(Duration.ofSeconds(5)).atMost(Duration.ofMinutes(10)).until(() -> {
             try {
-                setupEndpointForRestAssuredAdapterHttp();
                 Response response1 = RestAssured
                     .given()
                     .contentType(ContentType.JSON)
                     .accept(ContentType.JSON)
                     .when()
-                    .get(URI.create("/deephealth")).andReturn();
+                    .get(toURI(BASE_PATH_ACTUATOR + "/deephealth", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
     
                 DeepSystemStatusResponse deepSystemStatusResponse1 = gson.fromJson(response1.getBody().asString(),
                     DeepSystemStatusResponse.class);

--- a/service/src/test/java/se/jsquad/integration/MonitorPrometheusUpStatusIT.java
+++ b/service/src/test/java/se/jsquad/integration/MonitorPrometheusUpStatusIT.java
@@ -19,29 +19,27 @@ package se.jsquad.integration;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.net.URI;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static se.jsquad.integration.RyukIntegration.BASE_PATH_ACTUATOR;
+import static se.jsquad.integration.RyukIntegration.OPENBANK_MONITORING;
+import static se.jsquad.integration.RyukIntegration.PROTOCOL_HTTP;
 
 public class MonitorPrometheusUpStatusIT extends AbstractTestContainerSetup {
-    @BeforeEach
-    void setupEndpointForRestAssured() {
-        setupEndpointForRestAssuredAdapterHttp();
-    }
-    
     @Test
-    void testDeepHealthMetricsOk() {
+    void testDeepHealthMetricsOk() throws MalformedURLException, URISyntaxException {
         // When
         Response response = RestAssured
                 .given()
                 .contentType(ContentType.ANY)
                 .accept(ContentType.ANY)
                 .when()
-                .get(URI.create("/prometheus")).andReturn();
+                .get(toURI(BASE_PATH_ACTUATOR + "/prometheus", PROTOCOL_HTTP, OPENBANK_MONITORING)).andReturn();
 
         // Then
         assertEquals(200, response.getStatusCode());

--- a/service/src/test/java/se/jsquad/integration/RyukIntegration.java
+++ b/service/src/test/java/se/jsquad/integration/RyukIntegration.java
@@ -1,0 +1,79 @@
+package se.jsquad.integration;
+
+import io.restassured.RestAssured;
+import org.jasypt.util.text.BasicTextEncryptor;
+
+public abstract class RyukIntegration {
+    protected static final String CONTAINER_ENVIRONMENT = System.getenv("CONTAINER_ENVIRONMENT");
+    
+    protected static final String BASE_PATH_ACTUATOR = "/actuator";
+    protected static final String BASE_PATH_API = "/api";
+    protected static final String PROTOCOL_HTTP = "http";
+    protected static final String PROTOCOL_HTTPS = "https";
+    
+    protected static final int HTTP_K8_PORT = 80;
+    protected static final int HTTPS_K8_PORT = 443;
+    protected static final int MOCK_SERVER_PORT = 1080;
+    protected static final int MONITORING_PORT = 8081;
+    protected static final int POSTGRES_PORT = 5432;
+    protected static final int SERVICE_PORT = 8443;
+    
+    protected static final String DEFAULT_NAME_SPACE = "default";
+    protected static final String DOCKER_COMPOSE_SERVICE_NAME_ENDING = "_1";
+    protected static final String KUBERNETES_STARTER_SERVICE_NAME = "kubernetes-starter";
+    protected static final String LOCALHOST = "localhost";
+    protected static final String OPENBANK_DATABASE_NAME = "openbankdb";
+    protected static final String SECURITY_DATABASE_NAME = "securitydb";
+    protected static final String SERVICE_NAME = "openbank";
+    
+    public static final RyukService OPENBANK_SERVICE;
+    public static final RyukService OPENBANK_MONITORING;
+    public static final RyukService OPENBANK_DATABASE;
+    public static final RyukService SECURITY_DATABASE;
+    
+    static {
+        if (CONTAINER_ENVIRONMENT.equals("DOCKER")) {
+            OPENBANK_SERVICE = new RyukService(SERVICE_NAME, SERVICE_PORT);
+            OPENBANK_MONITORING = new RyukService(SERVICE_NAME, MONITORING_PORT);
+            OPENBANK_DATABASE = new RyukService(OPENBANK_DATABASE_NAME, POSTGRES_PORT);
+            SECURITY_DATABASE = new RyukService(SECURITY_DATABASE_NAME, POSTGRES_PORT);
+        } else {
+            OPENBANK_SERVICE = new RyukService(KUBERNETES_STARTER_SERVICE_NAME, HTTPS_K8_PORT);
+            OPENBANK_MONITORING = new RyukService(KUBERNETES_STARTER_SERVICE_NAME, HTTP_K8_PORT);
+            OPENBANK_DATABASE = null;
+            SECURITY_DATABASE = null;
+        }
+    }
+    
+    protected static void setupRestAssured() {
+        String encryptedPassword = "RMiukf/2Ir2Dr1aTGd0J4CXk6Y/TyPMN";
+        BasicTextEncryptor textEncryptor = new BasicTextEncryptor();
+        textEncryptor.setPassword(System.getenv("MASTER_KEY"));
+        RestAssured.trustStore("src/test/resources/test/ssl/truststore/jsquad.jks",
+            textEncryptor.decrypt(encryptedPassword));
+        
+        if (CONTAINER_ENVIRONMENT.equals("KUBERNETES")) {
+            RestAssured.useRelaxedHTTPSValidation();
+        }
+        
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+    
+    public static class RyukService {
+        private final String serviceName;
+        private final int port;
+        
+        public RyukService(final String serviceName, final int port) {
+            this.serviceName = serviceName;
+            this.port = port;
+        }
+        
+        public String getServiceName() {
+            return serviceName;
+        }
+        
+        public int getPort() {
+            return port;
+        }
+    }
+}


### PR DESCRIPTION
Refactored integration test setup to use common testcontainer
Ryuk container to easily integrate with services when executing
URI calls by generating service container's host and 'port'
dynamically.

For Docker environment the service containers are accessed by the
configured docker-compose-int.yaml file. In a Kubernetes
environment the services are accessed through the kubernetes-starter
container defined by the docker-compose-k8-integration.yaml file.