### PR TITLE
Added new production encryption keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@
 #
 
 dist: focal
-
 services:
   - docker
 
@@ -74,6 +73,7 @@ jobs:
         - find **/target/** -name "*.log" -exec travis-artifacts upload --path {} \;
     - stage: run integration tests in Kubernetes
       script:
+        - source setup_production_environment_variables.sh
         - source setup_kubernetes_integration_environment.sh
         - docker-compose -f service/src/test/resources/docker-compose-k8-integration.yaml build --force
         - travis_wait 60 mvn verify -Pintegrationtests
@@ -86,5 +86,5 @@ jobs:
         - docker push jsquadab/openbank-spring:latest
 env:
   global:
-    - SH=bash
-    - secure: kT+kPtRx05Epih2BDyUPdb190gJYhABBa0gOAvnn1nvpBCgCm3Uq2PM1aTMNOpyPtVBPh5r9amJOo99Cm8vUC3/12UiUHstACfCNoWTBUhu/rNOYx6w8oPzEmo5lGwXS3/8s1GnTDlwbzmYvOHV2vflyxx3UTlrdH79gsCKIUME3vMaoJ6DnMFeLrBuyzWqwHvXtS8xCxOGHxS3WmTMtxnIqRJ7iNhmvphVbB+ocXvihxoYiDKw5Feo+Fda51UFNyvByHAsdaoJCgGTEA6n+sY6Kfmeohet3qYs/1samQqPj4sutGtiYHSRkp6SpcdM4oTHCuLZQ37ixmdRZdziHcPPWngXRXG/m3gQib6StvJ/fno63I5jzuq//Hk9noal/g7gNcoAYuNAxhmwczyEgrdbUpvt1E21t++1V8KJASuriyfEnr/UKnyfQTxodP1AZbVut7IwUPR14KR1y8VFd8BuAM+mJfux3N04HUc/MkwinaunjthvdVffCcV8KCVMbK5MR/RL/Zg1i7e1xhTckpJIoYEZBgQf7fXUKwdKX+jKAFBXGEgegm3DqzqIEGLMp3zpt6VNNt+SUUfOo89jljxc2vSoTvOx06RtLRrD+iHT74uBslnf9BEBWlHL4Ms8wOKoPrQCsbPJuotGX2zw8L3ONEwetwWuX64aH5MBN1nM=
+  - SH=bash
+  - secure: reHv+UYQsFrg6nVzmjya/yuvFl0otKaBq4cGAXhVaEMiFWIfwnETR/BghQCSo07htAzN0/tMaYUcmsf2+5gw3mxsC7gMZX+JQVRjHsVIl6VbNdHgJCYAG00nHZa9TsJXvI3o0rV0Pzv6dKqlrn5NKrIL/ZEpUCcoZKYyMTZJpE9q1BKN/YsBEZp2vyn7rAcqzKcwqSmcysSsfAIHrYnHBb/6ZFVtiwDY0FA9O6GvAxUO1P9sKp+nxISH4hEtIHB8ZgXdhDfM7KEBnCCmjCyQlaIPgo6xAK/E07C8NHsdMiwGGyQ3N8YhsOa3Hvc9XnST3isflUbQ1xKKK4ay14k7wg+ijtwmBfT5Xi5RCxaMe8UvCz5FCORYIQn77JTTJICVqPFXEJwAa3JPiVGejtFHWzYVEylCqSZ+8efWwnUjqnQddirwGrnzsS+FKXrSQytVfSp7QgJkz1PiUXG2Jvl/Hubq0lQiBsGxQs/57dDJr451MDROR78OFQA0ltcLuUreCHWc1XEHDNQJUnKMxWiSmfzoPTwUKbtNuHSRdi9UIsxN9apKWnewLffRCy3M+DyN7FFS1Sl5ieRaHcd+cAAutlnjgwiKz7GJ8H6Is/hs63nk9oa7+E1FMK3FdqaSt5GvFLPdZPExTGuaJBcwA1UitJuz1RKpxHegRUN3LaTsYm4=

--- a/deployment/10_openbank_spring.yaml
+++ b/deployment/10_openbank_spring.yaml
@@ -47,4 +47,4 @@ spec:
                   name: openbank-spring-secret
                   key: MASTER_KEY
             - name: CONFIG_FILE_LOCATIONS
-              value: "classpath:application.properties,classpath:configuration_local.yaml,classpath:activemq.properties,classpath:openbank_jpa.yaml,classpath:security_jpa.yaml"
+              value: "classpath:application.properties,classpath:configuration_prod.yaml,classpath:activemq.properties,classpath:openbank_jpa.yaml,classpath:security_jpa.yaml"

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <rest.assured.version>4.0.0</rest.assured.version>
         <spring.boot.version>2.3.7.RELEASE</spring.boot.version>
         <springdoc.openapi.version>1.1.49</springdoc.openapi.version>
-        <testcontainers.junit.version>1.15.1</testcontainers.junit.version>
+        <testcontainers.junit.version>1.15.2</testcontainers.junit.version>
         <urm.version>1.4.8</urm.version>
         <versions.maven.plugin.version>2.7</versions.maven.plugin.version>
     </properties>

--- a/service/src/main/resources/configuration_prod.yaml
+++ b/service/src/main/resources/configuration_prod.yaml
@@ -1,0 +1,37 @@
+openbank.datasource:
+  url: jdbc:postgresql://openbankdb:5432/openbank
+  username: openbank_user
+  password: ENC(EOKoo1X2rkgJ3TWqZdmEnvf26B7Pox31DyCxmIGR0g7AHxuBF0b8tw==)
+  driverclassname: org.postgresql.Driver
+
+security.datasource:
+  url: jdbc:postgresql://securitydb:5432/security
+  username: security_user
+  password: ENC(+TO9xz4lgbNususDouCXaAsfJsUxh8+pqPa/lphrUyH1TBt/rfxBdnqYn+p9pTPk)
+  driverclassname: org.postgresql.Driver
+
+server.port: 8443
+server.ssl.key-store-type: PKCS12
+server.ssl.key-store: classpath:ssl/keystore/jsquad.pfx
+server.ssl.key-store-password: ENC(eOu0ofoinzH39JgEaEDa5REDKyIgIg9x)
+server.ssl.enabled: true
+
+world.webclient.baseUrl: http://mockserver:1080
+
+management.endpoint:
+  prometheus:
+    enabled: true
+  metrics.enabled: true
+
+management:
+  server:
+    port: 8081
+    ssl:
+      enabled: false
+
+management.endpoints:
+  web:
+    base-path: /actuator
+    exposure.include: 'shallowhealth,deephealth,metrics,prometheus'
+
+management.metrics.export.prometheus.enabled: true

--- a/service/src/test/java/se/jsquad/integration/RyukIntegration.java
+++ b/service/src/test/java/se/jsquad/integration/RyukIntegration.java
@@ -46,7 +46,7 @@ public abstract class RyukIntegration {
     }
     
     protected static void setupRestAssured() {
-        String encryptedPassword = "RMiukf/2Ir2Dr1aTGd0J4CXk6Y/TyPMN";
+        String encryptedPassword = System.getenv("SSL_ENCRYPTED_PASSWORD");
         BasicTextEncryptor textEncryptor = new BasicTextEncryptor();
         textEncryptor.setPassword(System.getenv("MASTER_KEY"));
         RestAssured.trustStore("src/test/resources/test/ssl/truststore/jsquad.jks",

--- a/setup_production_environment_variables.sh
+++ b/setup_production_environment_variables.sh
@@ -16,20 +16,20 @@
 # limitations under the License.
 #
 
-MASTER_KEY=SECRET_JSQUAD_AB_KEY # For demo purpose only, normally only stored at the CI/hidden environment
+MASTER_KEY=$PROD_MASTER_KEY
 
-SSL_ENCRYPTED_PASSWORD="RMiukf/2Ir2Dr1aTGd0J4CXk6Y/TyPMN"
+SSL_ENCRYPTED_PASSWORD="zDleNj2j6+QvzxWxAAKT9u65SFOzu2PF"
 
 ROOT_PASSWORD=$(java -cp ~/.m2/repository/org/jasypt/jasypt/1.9.3/jasypt-1.9.3.jar \
 org.jasypt.intf.cli.JasyptPBEStringDecryptionCLI \
-input="kns7TCKMYQNS7XewfgrcvSD6Ml0IxaNb9+rI4IJDm1JODeX39WDbvA==" password=$MASTER_KEY algorithm=PBEWithMD5AndDES | tail -n3 | awk 'NF')
+input="VmVV6iO8PUjIG+opClX4tMdH6bt5YgpFnkyMQr0nmBWhZmn7ZnCmHg==" password=$MASTER_KEY algorithm=PBEWithMD5AndDES | tail -n3 | awk 'NF')
 
 OPENBANK_PASSWORD=$(java -cp ~/.m2/repository/org/jasypt/jasypt/1.9.3/jasypt-1.9.3.jar \
 org.jasypt.intf.cli.JasyptPBEStringDecryptionCLI \
-input="DSQpSyewyvrR8AurZvZC0DUax5oSZSqRvGmcAVFwKGcTZTnshKQiTw==" password=$MASTER_KEY algorithm=PBEWithMD5AndDES | tail -n3 | awk 'NF')
+input="EOKoo1X2rkgJ3TWqZdmEnvf26B7Pox31DyCxmIGR0g7AHxuBF0b8tw==" password=$MASTER_KEY algorithm=PBEWithMD5AndDES | tail -n3 | awk 'NF')
 
 SECURITY_PASSWORD=$(java -cp ~/.m2/repository/org/jasypt/jasypt/1.9.3/jasypt-1.9.3.jar \
 org.jasypt.intf.cli.JasyptPBEStringDecryptionCLI \
-input="vNq9+oOFXPNeXnQwwcPWWjMCgjNMOS5z2tt1TkE7WVxXK4bib+K8/w==" password=$MASTER_KEY algorithm=PBEWithMD5AndDES | tail -n3 | awk 'NF')
+input="+TO9xz4lgbNususDouCXaAsfJsUxh8+pqPa/lphrUyH1TBt/rfxBdnqYn+p9pTPk" password=$MASTER_KEY algorithm=PBEWithMD5AndDES | tail -n3 | awk 'NF')
 
 export MASTER_KEY ROOT_PASSWORD OPENBANK_PASSWORD SECURITY_PASSWORD SSL_ENCRYPTED_PASSWORD


### PR DESCRIPTION
Added new encrypted property keys to be used by the CI environment
and by future cloud service and the new production master key
to be able to decrypt the secret property keys for security database,
openbank database, ssl client/server that CI/cloud environment is only
aware of.

Updated Testcontainers to version 1.15.2.

Refactored the SSL encrypted string to be able to execute integration
tests locally and for the test production environment.